### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.6"
     },
     "autoload": {
         "files": ["src/Burgomaster.php"]


### PR DESCRIPTION
require php >=5.3.6 for SplFileInfo::getExtension.

See : [5.3.6 Changelog](http://php.net/ChangeLog-5.php#5.3.6)

```
SPL extension:

    Fixed memory leak in DirectoryIterator::getExtension() and SplFileInfo::getExtension(). (Felipe)
    Fixed bug #53914 (SPL assumes HAVE_GLOB is defined). (Chris Jones)
    Fixed bug #53515 (property_exists incorrect on ArrayObject null and 0 values). (Felipe)
    Added SplFileInfo::getExtension(). FR #48767. (Peter Cowburn)

```
