### PR TITLE
#5 fixing the constant name in stub

### DIFF
--- a/src/Burgomaster.php
+++ b/src/Burgomaster.php
@@ -312,7 +312,7 @@ EOT
         $this->debug("Creating phar stub at $dest");
 
         $alias = $alias ?: basename($dest);
-        $constName = str_replace('.phar', '', strtoupper($alias)) . '_PHAR';
+        $constName = strtoupper(str_replace('.phar', '', $alias)) . '_PHAR';
         $stub  = "<?php\n";
         $stub .= "define('$constName', true);\n";
         $stub .= "Phar::mapPhar('$alias');\n";


### PR DESCRIPTION
Fixing issue #5 by moving `strtoupper` to fire after `str_replace`
